### PR TITLE
1.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+ > establish connection from NetBeans IDE to GitHub
+ > ...
+
 # WebsiteBaker Community Edition (WBCE)
 The [WebsiteBaker Community Edition](http://wbce.org) (`WBCE` or `WebsiteBaker CE`) is the further development of the classic content management system (CMS) [WebsiteBaker](http://websitebaker.org), based on [WebsiteBaker 2.8.3-SP4](http://wiki.websitebaker.org/wbdownload/SP4ForWb2-8-3.zip). 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
- > establish connection from NetBeans IDE to GitHub
- > ...
-
 # WebsiteBaker Community Edition (WBCE)
 The [WebsiteBaker Community Edition](http://wbce.org) (`WBCE` or `WebsiteBaker CE`) is the further development of the classic content management system (CMS) [WebsiteBaker](http://websitebaker.org), based on [WebsiteBaker 2.8.3-SP4](http://wiki.websitebaker.org/wbdownload/SP4ForWb2-8-3.zip). 
 

--- a/wbce/framework/initialize.php
+++ b/wbce/framework/initialize.php
@@ -10,10 +10,10 @@
  * @license GNU GPL2 (or any later version)
  */
 
-
+// define WB_PATH as it isn't yet defined
+defined("WB_PATH") OR define("WB_PATH", dirname(__DIR__));
 
 // DEFAULT SYSTEM SETTINGS
-
 // Set debug, but allow override in config. 
 if (!defined("WB_DEBUG")) define("WB_DEBUG", true);
  


### PR DESCRIPTION
The _**WB_PATH**_ constant is missing in frontend/initialize.php and backend/frontend shows 
>**Notice**: Use of undefined constant WB_PATH - assumed 'WB_PATH' in H:\WbPortable\root\wbce_dev\WebDesignWorx\WebsiteBaker_CommunityEdition\wbce\framework\classes\class.autoload.php on line 234
