### PR TITLE
Set correct FontAwesome URL in "Flat Theme" theme.css

### DIFF
--- a/wbce/templates/advancedThemeWbFlat/theme.css
+++ b/wbce/templates/advancedThemeWbFlat/theme.css
@@ -38,32 +38,18 @@
 }
 
 @font-face {
-    font-family: 'open_sans';
-    src:url('webfonts/fonts/opensans-italic-webfont.eot');
-    src:url('webfonts/fonts/opensans-italic-webfont.eot?#iefix') format('embedded-opentype'),
-        url('webfonts/fonts/opensans-italic-webfont.woff2') format('woff2'),
-        url('webfonts/fonts/opensans-italic-webfont.woff') format('woff'),
-        url('webfonts/fonts/opensans-italic-webfont.ttf') format('truetype'),
-        url('webfonts/fonts/opensans-italic-webfont.svg#open_sansitalic') format('svg');
-    font-weight: normal;
-    font-style: italic;
-
-}
-
-@font-face {
     font-family: 'FontAwesome';
-    src:url('webfonts/fonts/fontawesome-webfont.eot');
-    src:url('webfonts/fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
-        url('webfonts/fonts/fontawesome-webfont.woff2') format('woff2'),
-        url('webfonts/fonts/fontawesome-webfont.woff') format('woff'),
-        url('webfonts/fonts/fontawesome-webfont.ttf') format('truetype'),
-        url('webfonts/fonts/fontawesome-webfont.svg#fontawesome') format('svg');
+    src:url('../../include/font-awesome/fonts/fontawesome-webfont.eot');
+    src:url('../../include/font-awesome/fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
+        url('../../include/font-awesome/fonts/fontawesome-webfont.woff2') format('woff2'),
+        url('../../include/font-awesome/fonts/fontawesome-webfont.woff') format('woff'),
+        url('../../include/font-awesome/fonts/fontawesome-webfont.ttf') format('truetype'),
+        url('../../include/font-awesome/fonts/fontawesome-webfont.svg#fontawesome') format('svg');
     font-weight: normal;
     font-style: normal;
-
 }
 /* old theme as basis 
- * --> not alle elements get a new format 
+ * --> not all elements get a new format 
  * --------------------------------------------------------------------------------- */
 /* new theme starts from here 
  * --> overwrite old classes
@@ -72,7 +58,7 @@
  /* ::reste:: general resets for unique starting-point */
 html, body {
   height: 100%;
-  /* html, body: height 100%; - nur so spÃ¤ter height 100% fÃ¼r content mÃ¶glich */
+  /* html, body: height 100%; - nur so später height 100% für content möglich */
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
got lost in this commit: https://github.com/WBCE/WebsiteBaker_CommunityEdition/commit/291c0e9e809b1028680a99fef4c661b7245dff1e)