### PR TITLE
Update SecureForm.php

### DIFF
--- a/wbce/framework/classes/SecureForm.php
+++ b/wbce/framework/classes/SecureForm.php
@@ -139,7 +139,7 @@ class SecureForm
         $TimeSeed = floor(time() / $secrettime) * $secrettime; //round(floor) time() to whole days
         $DomainSeed = $_SERVER['SERVER_NAME'];                 // generate a numerical from server name.
 
-        $Seed = $TimeSeed + $DomainSeed;
+        $Seed = $TimeSeed . $DomainSeed;
         $secret .= md5($Seed); //
 
         $secret .= $this->_secret . $this->_serverdata . session_id();


### PR DESCRIPTION
For adding to strings together you should use dots. 

You will get a warning message in php 7.1 if you are using a plus for adding two strings together. 

Example message: 
Warning: A non-numeric value encountered in \foo\bar\framework\SecureForm.php on line 142